### PR TITLE
Updated class name to match Cloudflare's

### DIFF
--- a/src/kv_namespace.ts
+++ b/src/kv_namespace.ts
@@ -31,7 +31,7 @@ interface ListValue {
 
 type ValueTypeNames = 'text' | 'json' | 'arrayBuffer' | 'stream'
 
-export class EdgeKVNamespace implements KVNamespace {
+export class KvNamespace implements KVNamespace {
   protected kv: Map<string, InternalValue>
 
   constructor() {


### PR DESCRIPTION
I've got an implementation that tests whether a given "client" is a Cloudflare KV. I use this code:

```js
return client?.constructor?.name === "KvNamespace";
```

The issue with the code testing is that Cloudflare uses the `KvNamespace` class name, and `edge-mock` uses `EdgeKVNamespace` for the class name. With this PR, I'm hoping that edge-mock also uses the same name as Cloudflare to match better the mock.

In the Cloudflare Worker Editor, how this code:

<img width="517" alt="image" src="https://github.com/user-attachments/assets/6a15519d-ed13-47ce-b115-af43076f6f86">

Yields this result:

<img width="261" alt="image" src="https://github.com/user-attachments/assets/030de6ec-3ff8-40fc-a584-4ae22c518b8f">
